### PR TITLE
[CF-3720] As codefresh we should retry the container logger attach st…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/*.html
 coverage
 state.json
 *.log
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM node:onbuild
 
-CMD ["node", "lib/index.js"]
+#CMD ["node", "lib/index.js"]
+CMD ["node", "node_modules/.bin/forever", "--minUptime",  "1", "--spinSleepTime", "1000", "-c", "node", "lib/index.js"]

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -20,7 +20,9 @@ class Logger {
         this.firebaseSecret         = firebaseSecret;
         this.loggerId               = loggerId;
         this.findExistingContainers = findExistingContainers === 'true';
-        this.docker                 = new Docker();
+        this.docker                 = new Docker({
+            socketPath: '/var/run/codefresh/docker.sock',
+        });
     }
 
     /**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,7 @@ class Logger {
         this.loggerId               = loggerId;
         this.findExistingContainers = findExistingContainers === 'true';
         this.docker                 = new Docker({
-            socketPath: '/var/run/docker.sock',
+            socketPath: '/var/run/codefresh/docker.sock',
         });
     }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,7 @@ class Logger {
         this.loggerId               = loggerId;
         this.findExistingContainers = findExistingContainers === 'true';
         this.docker                 = new Docker({
-            socketPath: '/var/run/codefresh/docker.sock',
+            socketPath: '/var/run/docker.sock',
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "cf-logs": "git+https://github.com/codefresh-io/cf-logs.git#ceba4f309e52a077747a0c6bf9c3ad02e762dc4b",
     "dockerode": "^2.3.0",
     "firebase": "^2.4.1",
+    "forever": "^0.15.3",
     "lodash": "^4.15.0",
     "q": "^1.4.1"
   },


### PR DESCRIPTION
…rategy to support possible failures

Very simplified version
Uses 'forever' lib to restart logger on failure
Reads docker.sock from /var/run/codefresh instead of /var/run