### PR TITLE
build: reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.15.0-bookworm-slim as base
+FROM node:20.15.0-bookworm-slim AS base
 RUN adduser --disabled-password -home /home/cfu -shell /bin/bash cfu
 WORKDIR /root/cf-runtime
 COPY package.json yarn.lock ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,21 @@
-FROM node:20.8.1-bookworm-slim
-
+FROM node:20.15.0-bookworm-slim as base
+RUN adduser --disabled-password -home /home/cfu -shell /bin/bash cfu
 WORKDIR /root/cf-runtime
-
-RUN apt-get update && apt upgrade -y && \
-    apt-get install g++ git  make python3 -y
-
 COPY package.json yarn.lock ./
 
-# install cf-runtime required binaries
-RUN yarn install --frozen-lockfile --production && \
-    yarn cache clean && \
-    apt-get purge g++ git make python3 -y && \
-    apt-get autoremove -y && \
-    apt-get clean -y && \
-    rm -rf /tmp/* && \
-    rm -rf /var/lib/apt/lists/*
+FROM base AS dependencies
+RUN apt-get update \
+    && apt upgrade -y \
+    && apt-get install -y \
+    g++ \
+    git \
+    make \
+    python3
+RUN yarn install --frozen-lockfile --production
 
-# copy app files
-COPY . ./
-
-RUN adduser --disabled-password  -home /home/cfu -shell /bin/bash cfu
+FROM base AS production
+COPY --from=dependencies /root/cf-runtime/node_modules ./node_modules
+COPY . .
 
 USER cfu
-
 CMD ["node", "lib/index.js"]

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.11.4
+version: 1.11.5


### PR DESCRIPTION
## What

This reduces image size by 65%.

![image](https://github.com/codefresh-io/cf-container-logger/assets/32432324/c37d7e24-cb54-4da8-b1f2-cebfa069173e)

Also, this upgrades base image to node:20.15.0 which contains fixes for some CVEs.

## Why

Performance optimization.

## Notes

—

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
