### PR TITLE
fix(CR-28812): revert WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG NODE_VERSION=22.14.0
 FROM node:${NODE_VERSION}-bookworm-slim AS base
+# that workdir MUST NOT be changed because of backward compatibility with the engine <= 1.177.7
 WORKDIR /root/cf-runtime
 
 FROM base AS build-dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM base AS final
 RUN npm uninstall -g --logs-max=0 corepack npm
 USER node
 
-COPY --from=prod-dependencies --chown=node:node /app/node_modules node_modules
-COPY --from=build --chown=node:node /app/dist lib
+COPY --from=prod-dependencies --chown=node:node /root/cf-runtime/node_modules node_modules
+COPY --from=build --chown=node:node /root/cf-runtime/dist lib
 
 CMD ["node", "lib/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=22.14.0
 FROM node:${NODE_VERSION}-bookworm-slim AS base
-WORKDIR /app
+WORKDIR /root/cf-runtime
 
 FROM base AS build-dependencies
 RUN apt-get update \

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.12.4
+version: 1.12.5


### PR DESCRIPTION
## What

## Why
reverted workdir MUST NOT be changed because of backward compatibility with the engine <= 1.177.7
## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
